### PR TITLE
Feature/v2.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(*parts):
 
 setup(
     name='airflow-yeedu-operator',
-    version='2.9.0-rc8',
+    version='2.9.0-rc9',
     description='Submission and monitoring of jobs and notebooks using the Yeedu API in Apache Airflow.',
     long_description=read('README.md'),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(*parts):
 
 setup(
     name='airflow-yeedu-operator',
-    version='2.9.0-rc7',
+    version='2.9.0-rc8',
     description='Submission and monitoring of jobs and notebooks using the Yeedu API in Apache Airflow.',
     long_description=read('README.md'),
     long_description_content_type='text/markdown',

--- a/yeedu/operators/notebook_operator.py
+++ b/yeedu/operators/notebook_operator.py
@@ -47,10 +47,10 @@ class YeeduNotebookRunOperator:
         self.notebook_executed = True
         self.notebook_id = None
         self.cell_output_data = []
-        self.cells_info = {}
         self.execution_times = {}
         self.ws = None
         self.executionCount = 0
+        self.num_cells_execution = 0
         self.hook: YeeduHook = YeeduHook(
             conf_id=self.notebook_conf_id,
             tenant_id=self.tenant_id,
@@ -127,8 +127,8 @@ class YeeduNotebookRunOperator:
 
     def get_active_notebook_instances(self):
         TERMINAL_STATES = {"TERMINATED", "STOPPED", "ERROR"}
-        MAX_ATTEMPTS = 5
-        DELAY_SECONDS = 60
+        MAX_ATTEMPTS = 60
+        DELAY_SECONDS = 5
         get_params = {
             "notebook_conf_ids": self.notebook_conf_id,
             "notebook_status": "RUNNING",
@@ -385,6 +385,46 @@ class YeeduNotebookRunOperator:
             logger.error(f"Failed to calculate duration: {e}")
             return ""
 
+    def clear_notebook_cell_outputs(self):
+        try:
+            for cell in self.notebook_json.get("cells", []):
+                # Clear outputs
+                cell["outputs"] = []
+
+                # Clear execution metadata
+                cell_metadata = cell.setdefault("metadata", {})
+                cell_metadata.pop("startTime", None)
+                cell_metadata.pop("endTime", None)
+                cell_metadata.pop("lastRunTime", None)
+                cell["metadata"] = cell_metadata
+
+            logger.info(
+                "Cleared all previous outputs and execution metadata from notebook cells.")
+
+            # Persist the cleared notebook
+            update_cell_url = (
+                f"{self.base_url}workspace/{self.workspace_id}/notebook/{self.notebook_conf_id}/update"
+            )
+
+            update_cells_response = self.hook._api_request(
+                "POST", update_cell_url, self.notebook_json
+            )
+
+            logger.info(
+                f"Notebook clear-output update response: {update_cells_response.status_code}")
+
+            if update_cells_response.status_code == 201:
+                logger.info("Notebook cells cleared successfully.")
+            else:
+                raise Exception(
+                    f"Failed to clear notebook cells. Status code: {update_cells_response.status_code}, Message: {update_cells_response.text}"
+                )
+
+        except Exception as e:
+            logger.error(
+                f"An error occurred while clearing notebook cells: {e}")
+            raise
+
     def update_notebook_cells(self):
         try:
             msg_id_to_update = self.cell_output_data[0]["msg_id"]
@@ -471,6 +511,7 @@ class YeeduNotebookRunOperator:
                 f"Received message of type: {msg_type} with message id: ({msg_id})")
 
             self.wait_for_kernel_status(skip_sleep=True)
+
             if msg_type == "execute_result":
                 content = response.get("content", {})
                 logger.debug(
@@ -499,6 +540,7 @@ class YeeduNotebookRunOperator:
                         "output_type": "image",
                         "Celloutput": image_resp_url,
                     })
+
             elif msg_type == "error":
                 content = response.get("content", {})
                 self.error_name = content.get("ename", "")
@@ -538,10 +580,12 @@ class YeeduNotebookRunOperator:
                 )
 
             elif msg_type == "execute_input":
+                self.num_cells_execution += 1
                 content = response.get("content", {})
                 code_input = content.get("code", "")
                 logger.debug(
                     f"Started code cell execution for message id ({msg_id}):\n{code_input}")
+
             elif msg_type == "stream":
                 content = response.get("content", {})
                 text_value = content.get("text", "")
@@ -553,6 +597,7 @@ class YeeduNotebookRunOperator:
                     "output_type": "text",
                     "Celloutput": text_value
                 })
+
             elif msg_type == "display_data":
                 content = response.get("content", {})
                 logger.debug(f"Display Data: {content}")
@@ -575,6 +620,7 @@ class YeeduNotebookRunOperator:
                         "output_type": "text",
                         "Celloutput": text_resp
                     })
+
             elif msg_type == "status":
                 execution_state = response.get(
                     "content", {}).get("execution_state", "")
@@ -585,12 +631,23 @@ class YeeduNotebookRunOperator:
                         msg_id, {})["endTime"] = end_time
                 if self.cell_output_data:
                     self.update_notebook_cells()
+                else:
+                    if self.num_cells_execution > 0:
+                        self.cell_output_data.append({
+                            "msg_id": msg_id,
+                            "output_type": "text",
+                            "Celloutput": ''
+                        })
+                        self.update_notebook_cells()
+
             elif msg_type == "execute_reply":
                 content = response.get("content", {})
                 self.content_status = content.get("status", "")
                 self.error_name = content.get("ename", "")
+
                 logger.debug(
                     f"Execute reply content for message id ({msg_id}) : {content}")
+
                 if self.content_status == "ok":
                     try:
                         self.executionCount += 1
@@ -607,6 +664,7 @@ class YeeduNotebookRunOperator:
                         )
                     except ValueError:
                         pass
+
                 elif self.content_status == "error":
                     self.error_value = content.get("evalue", "")
                     traceback = content.get("traceback", [])
@@ -649,6 +707,7 @@ class YeeduNotebookRunOperator:
                     logger.debug(
                         "Setting notebook executed flag to False due to cell abort.")
                     self.notebook_executed = False
+
                 else:
                     raise Exception(
                         f"Invalid self.content_status: {self.content_status}"
@@ -863,11 +922,17 @@ class YeeduNotebookRunOperator:
                     "store_history": True,
                     "user_expressions": {},
                     "allow_stdin": False,
+                    # A boolean flag, which, if True, aborts the execution queue if an exception is encountered.
+                    # If False, queued execute_requests will execute even if this request generates an exception.
+                    # Reference Link: https://jupyter-client.readthedocs.io/en/stable/messaging.html#execute
+                    "stop_on_error": True,
                 },
                 "buffers": [],
                 "parent_header": {},
                 "channel": "shell",
             }
+            logger.debug(
+                f"Sending execute request for cell with message id ({msg_id}): {execute_request}")
             ws.send(json.dumps(execute_request))
         except Exception as e:
             logger.error(f"Error while sending execute request: {e}")
@@ -893,10 +958,8 @@ class YeeduNotebookRunOperator:
 
             self.notebook_json = notebook_download_response
             self.notebook_cells = notebook_download_response.get("cells", [])
-            self.cells_info = copy.deepcopy(self.notebook_cells)
 
-            for cell in self.cells_info:
-                cell.update({"outputs": []})
+            self.clear_notebook_cell_outputs()
 
             session_id = str(uuid.uuid4())
 


### PR DESCRIPTION
Change log: 
 - Implemented logic to clear previous cell execution results before starting a new execution.
 - Added `stop_on_error=true` flag to the `execute_request` sent to the Jupyter kernel, ensuring that subsequent cells in the queue are aborted when an error is encountered.
 - Fixed the calculation of cell execution time by correcting the placement of the `start_time`.
 - Reduced the retry interval from `60 seconds` to `5 seconds` (with the same total duration of `5 minutes`) when transitioning the notebook from SUBMITTED to RUNNING before establishing a websocket connection.
 - Removed the `notebook_executed=False` flag from the `msg_type=error` event, as this is now handled by the `stop_on_error=true` flag.